### PR TITLE
added a missing dependency, upgraded two modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,15 +32,16 @@
     "es6-promise": "^3.2.1",
     "express": "^4.14.0",
     "isomorphic-fetch": "^2.2.1",
-    "material-ui": "^0.15.0",
+    "material-ui": "^0.16.4",
     "mobx": "^2.4.3",
     "mobx-react": "^3.5.5",
     "radium": "^0.18.1",
     "react": "^15.0.1",
     "react-addons-shallow-compare": "^15.3.1",
+    "react-cookie": "^1.0.4",
     "react-dom": "^15.0.1",
     "react-responsive": "^1.1.4",
     "react-router": "^2.6.1",
-    "react-tap-event-plugin": "^1.0.0"
+    "react-tap-event-plugin": "^2.0.1"
   }
 }


### PR DESCRIPTION
Was initially missing react-cookie, then after running got error message "Cannot resolve module 'react/lib/EventPluginHub'" and [from this issue](https://github.com/prescottprue/generator-react-firebase/issues/24) it seemed to be based on versions of material-ui and react-tap-event-plugin. Updated those modules in package.json, problem went away.  